### PR TITLE
[codex] consolidar duração real das sessões

### DIFF
--- a/docs/study-cycle-strategic-page-plan.md
+++ b/docs/study-cycle-strategic-page-plan.md
@@ -472,7 +472,7 @@ Esta camada transforma o ciclo em orientacao diaria concreta: quantos topicos in
 - [x] Eventos especificos da fila/ciclo existem para: iniciar topico novo, revisar/retomar topico antigo, marcar materia, devolver materia, reordenar fila.
 - [x] O sistema salva `cycle_number` e `subject_position` em cada acao de estudo registrada no ciclo.
 - [ ] `study_sessions` registra sessoes, mas nao diferencia bem evento de primeiro contato vs revisao/retorno a topico ja aberto.
-- [ ] Confirmar schema atual de `study_sessions`: o hook usa `session_duration_minutes`, enquanto a migracao base mostra `duration_minutes`; corrigir antes de depender desse dado.
+- [x] Confirmar schema atual de `study_sessions`: concluido em 2026-07-05. A migration de criacao `20250608011928_563f1fe1-c11e-46a4-a248-a50ef31e0374.sql`, os tipos gerados e consulta direta ao `information_schema.columns` no banco de producao confirmaram somente `session_duration_minutes` (`integer`, nullable); `duration_minutes` nao existe. `useRealStatistics` deixou de declarar/criar fallback para a coluna fantasma e passou a normalizar todos os agregados pela fonte real com utilitario puro e teste focado.
 - [ ] Ainda nao existe uma tabela/agregado diario especifico para meta calculada do ciclo.
 
 ### Calculos viaveis agora

--- a/docs/superpowers/plans/2026-07-05-cycle-exam-date-editor.md
+++ b/docs/superpowers/plans/2026-07-05-cycle-exam-date-editor.md
@@ -52,4 +52,4 @@
 - [x] Rodar testes focados, `npm run typecheck`, `npm run lint`, `npm run test:run`, `npm run build` e `git diff --check`.
 - [x] Validar desktop/mobile no navegador autenticado.
 - [x] Marcar o debito como concluido somente apos todas as verificacoes.
-- [ ] Commitar, enviar branch, abrir PR, mergear e confirmar Vercel/Quality Gate em producao.
+- [x] Commitar, enviar branch, abrir PR, mergear e confirmar Vercel/Quality Gate em producao. Concluido no PR #23, commit `d74d395b`.

--- a/docs/superpowers/plans/2026-07-05-study-session-duration-schema.md
+++ b/docs/superpowers/plans/2026-07-05-study-session-duration-schema.md
@@ -1,0 +1,32 @@
+# Study Session Duration Schema Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remover a coluna fantasma `duration_minutes` dos calculos de estatistica e consolidar `study_sessions.session_duration_minutes` como fonte unica.
+
+**Architecture:** Um utilitario puro normaliza a duracao persistida e o hook de estatisticas o reutiliza em todos os agregados. Nenhuma migration e necessaria porque schema gerado, migration de criacao e consumidores de escrita ja convergem na coluna correta.
+
+**Tech Stack:** TypeScript, Supabase generated types e Vitest.
+
+---
+
+### Task 1: Fixar a fonte de duracao
+
+**Files:**
+- Create: `src/utils/studySessionDuration.ts`
+- Test: `src/utils/studySessionDuration.test.ts`
+- Modify: `src/hooks/useRealStatistics.tsx`
+
+- [x] Escrever teste para duracao ausente, real e negativa.
+- [x] Confirmar RED por modulo inexistente.
+- [x] Implementar normalizacao minima sobre `session_duration_minutes`.
+- [x] Remover `duration_minutes` do tipo local e de todos os agregados.
+- [x] Confirmar testes, typecheck, lint e build.
+
+### Task 2: Fechar o debito e publicar
+
+**Files:**
+- Modify: `docs/study-cycle-strategic-page-plan.md`
+
+- [x] Registrar schema confirmado e marcar o item concluido.
+- [ ] Criar PR, mergear e confirmar Quality Gate/Vercel em producao.

--- a/src/hooks/useRealStatistics.tsx
+++ b/src/hooks/useRealStatistics.tsx
@@ -20,6 +20,7 @@ import {
 } from 'date-fns';
 import { Subject, Topic } from '@/types';
 import { isVisibleCycleTopic, getVisibleCycleTopics } from '@/utils/studyCycleTopicVisibility';
+import { getStudySessionDurationMinutes } from '@/utils/studySessionDuration';
 import { getStatisticsStudyTime } from '@/utils/statisticsStudyTime';
 
 export interface RealStatisticsData {
@@ -143,8 +144,7 @@ interface StudySession {
   started_at: string;
   completed_at: string;
   study_date: string;
-  duration_minutes?: number;
-  session_duration_minutes?: number; // Campo alternativo do banco
+  session_duration_minutes?: number | null;
   topics_studied: string[];
   topics_count: number;
   hour_of_day: number;
@@ -346,7 +346,6 @@ export const useRealStatistics = (filter: StatisticsFilter = { type: 'cycle' }):
         // Transformar dados do banco para o formato esperado
         const transformedSessions = (sessionsData as StudySession[] | null || []).map((session) => ({
           ...session,
-          duration_minutes: session.duration_minutes || session.session_duration_minutes || 0,
           topics_studied: Array.isArray(session.topics_studied) ? session.topics_studied : []
         })) as StudySession[];
         
@@ -418,7 +417,7 @@ export const useRealStatistics = (filter: StatisticsFilter = { type: 'cycle' }):
 
     // Calcular visão geral com dados reais
     const totalStudyTimeFromSessions = studySessions.reduce((sum, session) => 
-      sum + (session.duration_minutes || session.session_duration_minutes || 0), 0);
+      sum + getStudySessionDurationMinutes(session.session_duration_minutes), 0);
     const totalStudyTimeFromPomodoro = pomodoroSessions.reduce((sum, session) => 
       sum + (session.total_minutes_studied || 0), 0);
     
@@ -489,7 +488,7 @@ export const useRealStatistics = (filter: StatisticsFilter = { type: 'cycle' }):
       const current = subjectSessionsMap.get(session.subject_id) || { sessions: 0, totalTime: 0 };
       subjectSessionsMap.set(session.subject_id, {
         sessions: current.sessions + 1,
-        totalTime: current.totalTime + (session.duration_minutes || session.session_duration_minutes || 0)
+        totalTime: current.totalTime + getStudySessionDurationMinutes(session.session_duration_minutes)
       });
     });
 
@@ -583,7 +582,7 @@ export const useRealStatistics = (filter: StatisticsFilter = { type: 'cycle' }):
       mostProductiveDay: dayNames[mostProductiveDayNum] || 'Segunda',
       mostProductiveHour: mostProductiveHourNum !== null ? `${mostProductiveHourNum.toString().padStart(2, '0')}:00` : null,
       averageSessionTime: userAnalytics?.media_duracao_sessao || 
-        (studySessions.length > 0 ? Math.round(studySessions.reduce((sum, s) => sum + (s.duration_minutes || s.session_duration_minutes || 0), 0) / studySessions.length) : 45),
+        (studySessions.length > 0 ? Math.round(studySessions.reduce((sum, session) => sum + getStudySessionDurationMinutes(session.session_duration_minutes), 0) / studySessions.length) : 45),
       averageTopicsPerDay: userAnalytics?.media_sessoes_por_dia || 
         (studySessions.length > 0 ? Math.round(studySessions.reduce((sum, s) => sum + (s.topics_count || 0), 0) / daysWithSessions) : 3),
       consistencyRate: daysWithSessions > 0 ? Math.round((daysWithSessions / 30) * 100) : 0,

--- a/src/utils/studySessionDuration.test.ts
+++ b/src/utils/studySessionDuration.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { getStudySessionDurationMinutes } from './studySessionDuration';
+
+describe('getStudySessionDurationMinutes', () => {
+  it.each([
+    { input: null, expected: 0 },
+    { input: undefined, expected: 0 },
+    { input: 25, expected: 25 },
+    { input: -5, expected: 0 },
+  ])('normalizes $input to $expected minutes', ({ input, expected }) => {
+    expect(getStudySessionDurationMinutes(input)).toBe(expected);
+  });
+});

--- a/src/utils/studySessionDuration.ts
+++ b/src/utils/studySessionDuration.ts
@@ -1,0 +1,3 @@
+export const getStudySessionDurationMinutes = (
+  sessionDurationMinutes: number | null | undefined,
+) => Math.max(0, Number(sessionDurationMinutes || 0));


### PR DESCRIPTION
## Resumo
- confirma no schema de produção que `study_sessions` usa somente `session_duration_minutes`
- remove o fallback frontend para a coluna inexistente `duration_minutes`
- centraliza normalização de minutos reais e bloqueia valores negativos
- fecha o débito correspondente no plano vivo

## Validação
- consulta read-only ao `information_schema.columns` em produção
- `npm run typecheck`
- `npm run lint`
- `npm run test:run` (67 arquivos, 319 testes)
- `npm run build`
- `git diff --cached --check`